### PR TITLE
feat: minimal SNS SOAR MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+backend/db.json
+frontend/dist

--- a/backend/connectors.js
+++ b/backend/connectors.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+const samples = path.join(__dirname, '../samples');
+class Connector {
+  constructor(name) { this.name = name; this.data = JSON.parse(fs.readFileSync(path.join(samples, name + '.json'))); }
+  listAlerts() { return this.data.alerts; }
+}
+const names = ['sekoia', 'sentinelone', 'fortiedr', 'rangerad', 'vectra', 'aisiem'];
+const objs = Object.fromEntries(names.map(n => [n, new Connector(n)]));
+module.exports = objs;
+module.exports.Connector = Connector;

--- a/backend/engine.js
+++ b/backend/engine.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const yaml = require('yaml');
+const store = require('./store');
+function run(pbPath, alert) {
+  const pb = yaml.parse(fs.readFileSync(pbPath, 'utf8'));
+  for (const s of pb.steps) {
+    if (s.action === 'tag') alert.tags = (alert.tags || []).concat(s.value);
+    if (s.action === 'close') alert.status = 'closed';
+    if (s.action === 'comment') alert.comments = (alert.comments || []).concat(s.value);
+  }
+  store.addExecution({ playbook: pb.name, alertId: alert.id, ts: Date.now() });
+}
+module.exports = { run };

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const store = require('./store');
+const engine = require('./engine');
+const connectors = require('./connectors');
+const path = require('path');
+const app = express();
+app.use(express.json());
+app.get('/alerts', (req, res) => res.json(store.listAlerts()));
+app.post('/ingest', (req, res) => { store.addAlert(req.body); res.json({ ok: 1 }); });
+app.post('/alerts/:id/run/:pb', (req, res) => {
+  const a = store.getAlert(req.params.id);
+  engine.run(path.join(__dirname, '../samples', req.params.pb + '.yml'), a);
+  res.json(a);
+});
+app.get('/connectors/:name/alerts', (req, res) => res.json(connectors[req.params.name]?.listAlerts() || []));
+app.listen(3001, () => console.log('backend on 3001'));

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sns-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "node index.js",
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "yaml": "^2.3.1"
+  }
+}

--- a/backend/store.js
+++ b/backend/store.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+const file = path.join(__dirname, 'db.json');
+let data = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file)) : { alerts: [], executions: [] };
+function save() { fs.writeFileSync(file, JSON.stringify(data)); }
+module.exports = {
+  listAlerts: () => data.alerts,
+  getAlert: id => data.alerts.find(a => a.id === id),
+  addAlert: alert => { if (!data.alerts.some(a => a.id === alert.id)) { data.alerts.push(alert); save(); } },
+  addExecution: exec => { data.executions.push(exec); save(); },
+  reset: () => { data = { alerts: [], executions: [] }; save(); }
+};

--- a/backend/test.js
+++ b/backend/test.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+const store = require('./store');
+const engine = require('./engine');
+const connectors = require('./connectors');
+const path = require('path');
+store.reset();
+store.addAlert({ id: '1', title: 'a' });
+store.addAlert({ id: '1', title: 'a' });
+assert.equal(store.listAlerts().length, 1);
+engine.run(path.join(__dirname, '../samples/close.yml'), store.getAlert('1'));
+assert.equal(store.getAlert('1').status, 'closed');
+assert(connectors.sekoia.listAlerts().length && connectors.sentinelone.listAlerts().length);
+console.log('backend tests ok');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sns-frontend",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "@testing-library/react": "^14.0.0",
+    "vitest": "^0.34.6",
+    "vite": "^5.0.0",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+export default function App() {
+  const [alerts, setAlerts] = useState([]);
+  const [filter, setFilter] = useState('');
+  useEffect(() => { fetch('/alerts').then(r => r.json()).then(setAlerts); }, []);
+  const list = alerts.filter(a => a.title.includes(filter));
+  return (
+    <div>
+      <input placeholder="filter" value={filter} onChange={e => setFilter(e.target.value)} />
+      <ul>
+        {list.map(a => (
+          <li key={a.id}>
+            {a.title}
+            <button onClick={() => fetch(`/alerts/${a.id}/run/close`, { method: 'POST' })}>run</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+createRoot(document.getElementById('root')).render(<App />);

--- a/frontend/test/app.test.jsx
+++ b/frontend/test/app.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import App from '../src/App';
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve([{ id: '1', title: 'a' }, { id: '2', title: 'b' }]) }));
+});
+describe('App', () => {
+  it('lists, filters and runs playbook', async () => {
+    render(<App />);
+    await screen.findByText('a');
+    fireEvent.change(screen.getByPlaceholderText('filter'), { target: { value: 'b' } });
+    await screen.findByText('b');
+    fireEvent.click(screen.getAllByText('run')[0]);
+    expect(fetch).toHaveBeenLastCalledWith('/alerts/2/run/close', { method: 'POST' });
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 3000, proxy: { '/alerts': 'http://localhost:3001', '/ingest': 'http://localhost:3001' } }
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+export default defineConfig({ plugins: [react()], test: { environment: 'jsdom' } });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sns-soar",
+  "private": true,
+  "scripts": {
+    "setup": "npm --prefix backend install && npm --prefix frontend install",
+    "dev": "concurrently \"npm --prefix backend run dev\" \"npm --prefix frontend run dev\"",
+    "test": "npm --prefix backend test && npm --prefix frontend test"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.0"
+  },
+  "workspaces": ["backend", "frontend"]
+}

--- a/samples/aisiem.json
+++ b/samples/aisiem.json
@@ -1,0 +1,1 @@
+{"alerts":[{"id":"a1","title":"AI SIEM alert"}]}

--- a/samples/close.yml
+++ b/samples/close.yml
@@ -1,0 +1,5 @@
+name: close
+steps:
+  - action: tag
+    value: test
+  - action: close

--- a/samples/fortiedr.json
+++ b/samples/fortiedr.json
@@ -1,0 +1,1 @@
+{"alerts":[{"id":"f1","title":"FortiEDR alert"}]}

--- a/samples/rangerad.json
+++ b/samples/rangerad.json
@@ -1,0 +1,1 @@
+{"alerts":[{"id":"r1","title":"RangerAD alert"}]}

--- a/samples/sekoia.json
+++ b/samples/sekoia.json
@@ -1,0 +1,1 @@
+{"alerts":[{"id":"s1","title":"Sekoia alert"}]}

--- a/samples/sentinelone.json
+++ b/samples/sentinelone.json
@@ -1,0 +1,1 @@
+{"alerts":[{"id":"se1","title":"SentinelOne alert"}]}

--- a/samples/vectra.json
+++ b/samples/vectra.json
@@ -1,0 +1,1 @@
+{"alerts":[{"id":"v1","title":"Vectra alert"}]}


### PR DESCRIPTION
## Summary
- add lightweight backend with in-memory JSON persistence, playbook engine, and mock connectors
- scaffold React console for viewing alerts and triggering playbooks
- provide sample data, playbook, and basic unit/E2E tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689b0aa3c188832fa84459128a85c280